### PR TITLE
PNLAN-51 Credits aren't getting parsed on these files #time 0h 39m #c…

### DIFF
--- a/src/main/java/com/github/adam6806/pnlanalyzer/controllers/TrialBalanceReportController.java
+++ b/src/main/java/com/github/adam6806/pnlanalyzer/controllers/TrialBalanceReportController.java
@@ -147,7 +147,7 @@ public class TrialBalanceReportController {
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(current.getDate());
         int month = calendar.get(Calendar.MONTH) + 1;
-        String fileName = month + "-" + calendar.get(Calendar.YEAR) + "-" + current.getCompany().getName() + ".iif";
+        String fileName = month + "-" + calendar.get(Calendar.YEAR) + "-" + current.getCompany().getName() + "-TBRResult.iif";
 
         Resource resource = new InputStreamResource(ExcelParser.generateJournalEntries(calculatedDifference, current));
 

--- a/src/main/java/com/github/adam6806/pnlanalyzer/utility/ExcelParser.java
+++ b/src/main/java/com/github/adam6806/pnlanalyzer/utility/ExcelParser.java
@@ -25,20 +25,35 @@ public class ExcelParser {
         List<LineItem> lineItemList = new ArrayList<>();
 
         Workbook workbook = WorkbookFactory.create(excelFile);
-        Sheet sheet = workbook.getSheetAt(0);
-        for (Row row : sheet) {
+        Sheet sheet1 = workbook.getSheetAt(0);
+        for (int i = 0; i < workbook.getNumberOfSheets(); i++) {
+            Sheet sheet = workbook.getSheetAt(i);
+            if ("Sheet1".equals(sheet.getSheetName())) {
+                sheet1 = sheet;
+                break;
+            }
+        }
+
+        int debitColumn = -1;
+        int creditColumn = -1;
+
+        for (Row row : sheet1) {
             if (row == null) continue;
             LineItem lineItem = new LineItem();
             boolean isLineItem = false;
             for (Cell cell : row) {
-                if (cell.getAddress().getRow() == 0 && cell.getAddress().getColumn() == 2) {
+                if (debitColumn == -1 && "Debit".equalsIgnoreCase(cell.getStringCellValue())) {
+                    debitColumn = cell.getColumnIndex();
+                } else if (creditColumn == -1 && "Credit".equalsIgnoreCase(cell.getStringCellValue())) {
+                    creditColumn = cell.getColumnIndex();
+                } else if (cell.getAddress().getRow() == 0 && cell.getAddress().getColumn() == 2) {
                     lineItem.setDescription(cell.getStringCellValue());
                 } else if (cell.getAddress().getColumn() == 1 && !cell.getStringCellValue().isEmpty()) {
                     isLineItem = true;
                     lineItem.setDescription(cell.getStringCellValue());
-                } else if (cell.getAddress().getColumn() == 2 && isLineItem) {
+                } else if (cell.getAddress().getColumn() == debitColumn && isLineItem) {
                     lineItem.setDebit(cell.getNumericCellValue());
-                } else if (cell.getAddress().getColumn() == 4 && isLineItem) {
+                } else if (cell.getAddress().getColumn() == creditColumn && isLineItem) {
                     lineItem.setCredit(cell.getNumericCellValue());
                 }
             }


### PR DESCRIPTION
…omment Issue here was two things. One, these files had the extra sheet in the front. Now we will look for a sheet called "Sheet1" and ignore everything else. The second thing was that there was a difference in which column the credits and debits were in. One of the files has a column between credits and debits. Probably a hidden column. The parser was looking for specific columns. Now, it checks for which column "Debit" and "Credit" are in and then uses that column for pulling all of the numbers. This new way is more robust and everything should work now for the two types of xsl files we've run into so far.